### PR TITLE
Update raid team options in application question

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Edit the `questions` list in [`src/bot.py`](src/bot.py:38-47):
 
 ```python
 questions = [
-    "Which raid team are you applying to? Weekday (Tues/Wed/Thurs), Weekend (Fri/Sat/Sun), Floater/Casual",
+    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual",
     "Have you reviewed the raid schedule for the team you're applying for?",
     "How did you hear about us?",
     "Is there a certain class/spec/role that you prefer to play?",

--- a/src/bot.py
+++ b/src/bot.py
@@ -36,7 +36,7 @@ intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 questions = [
-    "Which raid team are you applying to? Weekday (Tues/Mon), Weekend (Fri/Sat), Floater/Casual",
+    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual",
     "Have you reviewed the raid schedule for the team you're applying for?",
     "How did you hear about us?",
     "Is there a certain class/spec/role that you prefer to play?",


### PR DESCRIPTION
## Summary
- remove the inactive Weekday raid team from the application question
- update the README example so the documented question list matches the bot configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da08dec80c8324a333f36e79613f6a