### PR TITLE
Add weekday raid teams to application question

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Edit the `questions` list in [`src/bot.py`](src/bot.py:38-47):
 
 ```python
 questions = [
-    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual",
+    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual, 10M Weasals Weekday Team, 10M Casual Weekday Team",
     "Have you reviewed the raid schedule for the team you're applying for?",
     "How did you hear about us?",
     "Is there a certain class/spec/role that you prefer to play?",

--- a/src/bot.py
+++ b/src/bot.py
@@ -36,7 +36,7 @@ intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 questions = [
-    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual",
+    "Which raid team are you applying to? Weekend (Fri/Sat), Floater/Casual, 10M Weasals Weekday Team, 10M Casual Weekday Team",
     "Have you reviewed the raid schedule for the team you're applying for?",
     "How did you hear about us?",
     "Is there a certain class/spec/role that you prefer to play?",


### PR DESCRIPTION
## Summary
- update the applicant question so it lists the new weekday raid teams
- align the README customization example with the updated raid team list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d86fb5788324bc3d519d7b7f61d3